### PR TITLE
docs(icons): list icons from Allocations and Resource Catalog

### DIFF
--- a/icons.md
+++ b/icons.md
@@ -1,0 +1,45 @@
+# Icons
+
+## Allocations Website and Resource Catalog
+
+| Icon Name | Collection | Uses |
+| --- | --- | --- |
+| [arrows-fullscreen](https://icons.getbootstrap.com/icons/arrows-fullscreen/) | Bootstrap Icons | Enter full screen mode, Large memory |
+| [asterisk](https://icons.getbootstrap.com/icons/asterisk/) | Bootstrap Icons | Required field |
+| [book](https://icons.getbootstrap.com/icons/book/) | Bootstrap Icons | Documentation |
+| [boxes](https://icons.getbootstrap.com/icons/boxes/) | Bootstrap Icons | Project types |
+| [calendar-event-fill](https://icons.getbootstrap.com/icons/calendar-event-fill/) | Bootstrap Icons | Date field |
+| [calendar3](https://icons.getbootstrap.com/icons/calendar3/) | Bootstrap Icons | Announcements and events |
+| [caret-down](https://icons.getbootstrap.com/icons/caret-down/) | Bootstrap Icons | Open accordion section caret |
+| [caret-right](https://icons.getbootstrap.com/icons/caret-right/) | Bootstrap Icons | Closed accordion section caret |
+| [cash-coin](https://icons.getbootstrap.com/icons/cash-coin/) | Bootstrap Icons | ACCESS Credits (resource type) |
+| [chat-fill](https://icons.getbootstrap.com/icons/chat-fill/) | Bootstrap Icons | Ask.CI topics |
+| [check-circle](https://icons.getbootstrap.com/icons/check-circle/) | Bootstrap Icons | Yes (yes or no question) |
+| [check](https://icons.getbootstrap.com/icons/check/) | Bootstrap Icons | Selected item |
+| [check2-circle](https://icons.getbootstrap.com/icons/check2-circle/) | Bootstrap Icons | Get started (e.g., using a resource) |
+| [chevron-left](https://icons.getbootstrap.com/icons/chevron-left/) | Bootstrap Icons | Back/previous |
+| [chevron-right](https://icons.getbootstrap.com/icons/chevron-right/) | Bootstrap Icons | Forward/next |
+| [clock](https://icons.getbootstrap.com/icons/clock/) | Bootstrap Icons | Queue metrics |
+| [cpu-fill](https://icons.getbootstrap.com/icons/cpu-fill/) | Bootstrap Icons | Compute resource (resource type) |
+| [cpu](https://icons.getbootstrap.com/icons/cpu/) | Bootstrap Icons | GPU resource (resource type) |
+| [eye-fill](https://icons.getbootstrap.com/icons/eye-fill/) | Bootstrap Icons | Show item |
+| [file-earmark-pdf-fill](https://icons.getbootstrap.com/icons/file-earmark-pdf-fill/) | Bootstrap Icons | Document upload field |
+| [fullscreen-exit](https://icons.getbootstrap.com/icons/fullscreen-exit/) | Bootstrap Icons | Exit full screen mode |
+| [hdd-fill](https://icons.getbootstrap.com/icons/hdd-fill/) | Bootstrap Icons | Storage resource (resource type) |
+| [info-circle-fill](https://icons.getbootstrap.com/icons/info-circle-fill/) | Bootstrap Icons | More information (e.g., tooltip) |
+| [link](https://icons.getbootstrap.com/icons/link/) | Bootstrap Icons | Permalink (e.g., to a section of a page) |
+| [pc-display-horizontal](https://icons.getbootstrap.com/icons/pc-display-horizontal/) | Bootstrap Icons | Virtual machine |
+| [pc-display](https://icons.getbootstrap.com/icons/pc-display/) | Bootstrap Icons | Current projects |
+| [pencil](https://icons.getbootstrap.com/icons/pencil/) | Bootstrap Icons | Edit item |
+| [people-fill](https://icons.getbootstrap.com/icons/people-fill/) | Bootstrap Icons | Affinity group, Manage users, User (user role) |
+| [person-fill-add](https://icons.getbootstrap.com/icons/person-fill-add/) | Bootstrap Icons | Co-PI (user role) |
+| [person-fill-check](https://icons.getbootstrap.com/icons/person-fill-check/) | Bootstrap Icons | PI (user role) |
+| [person-fill-gear](https://icons.getbootstrap.com/icons/person-fill-gear/) | Bootstrap Icons | Allocation manager (user role) |
+| [person-plus](https://icons.getbootstrap.com/icons/person-plus/) | Bootstrap Icons | Add a user to a project |
+| [person-square](https://icons.getbootstrap.com/icons/person-square/) | Bootstrap Icons | Program/human resource (resource type) |
+| [plus-circle-fill](https://icons.getbootstrap.com/icons/plus-circle-fill/) | Bootstrap Icons | Add another item |
+| [table](https://icons.getbootstrap.com/icons/table/) | Bootstrap Icons | Tabular data |
+| [terminal](https://icons.getbootstrap.com/icons/terminal/) | Bootstrap Icons | Software |
+| [trash](https://icons.getbootstrap.com/icons/trash/) | Bootstrap Icons | Delete item |
+| [x-circle](https://icons.getbootstrap.com/icons/x-circle/) | Bootstrap Icons | No (yes or no question) |
+| [x-lg](https://icons.getbootstrap.com/icons/x-lg/) | Bootstrap Icons | Close (e.g., a modal dialog) |


### PR DESCRIPTION
This branch adds a Markdown page listing icons used in the Allocations Website and the forthcoming Resource Catalog interface.